### PR TITLE
Fix thread copy to duplicate checkpoint history

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -53,3 +53,4 @@ globs:
 - Store items have no indices beyond PK — could bottleneck on large stores
 - Pool acquisition: `async with self.pool.acquire() as conn` — single connection per query
 - All `fetch_*` methods return dicts via `dict(row)` conversion from asyncpg.Record
+- 2026-04-07: Checkpointer pool is psycopg (not asyncpg) — uses `%s` placeholders, acquired via `async with checkpointer.conn.connection() as conn`. The `$N` asyncpg convention applies only to the app-level `DatabasePool`, not the checkpointer/store psycopg pools.

--- a/src/langrove/services/thread_service.py
+++ b/src/langrove/services/thread_service.py
@@ -69,9 +69,37 @@ class ThreadService:
         return [self._to_thread(r) for r in rows]
 
     async def copy(self, thread_id: UUID) -> Thread:
-        """Copy a thread."""
+        """Copy a thread including all checkpoint history."""
         row = await self._repo.copy(thread_id)
+        new_thread_id = row["thread_id"]
+        if self._checkpointer:
+            await self._copy_checkpoints(str(thread_id), str(new_thread_id))
         return self._to_thread(row)
+
+    async def _copy_checkpoints(self, source_thread_id: str, dest_thread_id: str) -> None:
+        """Copy all checkpoints, blobs, and writes from one thread to another via direct SQL."""
+        async with self._checkpointer.conn.connection() as conn:
+            await conn.execute(
+                "INSERT INTO checkpoints"
+                " (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)"
+                " SELECT %s, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata"
+                " FROM checkpoints WHERE thread_id = %s ON CONFLICT DO NOTHING",
+                (dest_thread_id, source_thread_id),
+            )
+            await conn.execute(
+                "INSERT INTO checkpoint_blobs"
+                " (thread_id, checkpoint_ns, channel, version, type, blob)"
+                " SELECT %s, checkpoint_ns, channel, version, type, blob"
+                " FROM checkpoint_blobs WHERE thread_id = %s ON CONFLICT DO NOTHING",
+                (dest_thread_id, source_thread_id),
+            )
+            await conn.execute(
+                "INSERT INTO checkpoint_writes"
+                " (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob)"
+                " SELECT %s, checkpoint_ns, checkpoint_id, task_id, task_path, idx, channel, type, blob"
+                " FROM checkpoint_writes WHERE thread_id = %s ON CONFLICT DO NOTHING",
+                (dest_thread_id, source_thread_id),
+            )
 
     async def get_state(self, thread_id: UUID, checkpoint_id: str | None = None) -> ThreadState:
         """Get current thread state from the checkpointer."""

--- a/tests/test_thread_copy.py
+++ b/tests/test_thread_copy.py
@@ -1,0 +1,146 @@
+"""Tests for thread copy with checkpoint data."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from langrove.services.thread_service import ThreadService
+
+
+def _make_service(checkpointer=None):
+    repo = AsyncMock()
+    registry = MagicMock()
+    registry.list_graphs.return_value = []
+    return ThreadService(repo, checkpointer, registry)
+
+
+class TestThreadCopyNoCheckpointer:
+    @pytest.mark.asyncio
+    async def test_copy_without_checkpointer_returns_new_thread(self):
+        service = _make_service(checkpointer=None)
+        source_id = uuid4()
+        new_id = uuid4()
+        service._repo.copy.return_value = {
+            "thread_id": new_id,
+            "metadata": {"key": "value"},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+        thread = await service.copy(source_id)
+
+        service._repo.copy.assert_awaited_once_with(source_id)
+        assert thread.thread_id == new_id
+        assert thread.metadata == {"key": "value"}
+
+    @pytest.mark.asyncio
+    async def test_copy_without_checkpointer_no_checkpoint_sql(self):
+        service = _make_service(checkpointer=None)
+        service._repo.copy.return_value = {
+            "thread_id": uuid4(),
+            "metadata": {},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        # Should not raise even without checkpointer
+        await service.copy(uuid4())
+
+
+class TestThreadCopyWithCheckpointer:
+    def _make_mock_checkpointer(self):
+        mock_conn = AsyncMock()
+        mock_conn_ctx = AsyncMock()
+        mock_conn_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        checkpointer = MagicMock()
+        checkpointer.conn = MagicMock()
+        checkpointer.conn.connection = MagicMock(return_value=mock_conn_ctx)
+        return checkpointer, mock_conn
+
+    @pytest.mark.asyncio
+    async def test_copy_with_checkpointer_calls_three_inserts(self):
+        checkpointer, mock_conn = self._make_mock_checkpointer()
+        service = _make_service(checkpointer=checkpointer)
+        source_id = uuid4()
+        new_id = uuid4()
+        service._repo.copy.return_value = {
+            "thread_id": new_id,
+            "metadata": {},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+        await service.copy(source_id)
+
+        assert mock_conn.execute.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_copy_checkpoint_sql_uses_correct_thread_ids(self):
+        checkpointer, mock_conn = self._make_mock_checkpointer()
+        service = _make_service(checkpointer=checkpointer)
+        source_id = uuid4()
+        new_id = uuid4()
+        service._repo.copy.return_value = {
+            "thread_id": new_id,
+            "metadata": {},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+        await service.copy(source_id)
+
+        calls = mock_conn.execute.await_args_list
+        assert len(calls) == 3
+        for call in calls:
+            params = call[0][1]  # second positional arg = params tuple
+            assert params[0] == str(new_id)  # dest
+            assert params[1] == str(source_id)  # source
+
+    @pytest.mark.asyncio
+    async def test_copy_checkpoint_sql_covers_all_tables(self):
+        checkpointer, mock_conn = self._make_mock_checkpointer()
+        service = _make_service(checkpointer=checkpointer)
+        source_id = uuid4()
+        new_id = uuid4()
+        service._repo.copy.return_value = {
+            "thread_id": new_id,
+            "metadata": {},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+        await service.copy(source_id)
+
+        sqls = [call[0][0] for call in mock_conn.execute.await_args_list]
+        tables = {"checkpoints", "checkpoint_blobs", "checkpoint_writes"}
+        for table in tables:
+            assert any(table in sql for sql in sqls), f"Missing SQL for table {table}"
+
+    @pytest.mark.asyncio
+    async def test_copy_returns_new_thread_not_source(self):
+        checkpointer, mock_conn = self._make_mock_checkpointer()
+        service = _make_service(checkpointer=checkpointer)
+        source_id = uuid4()
+        new_id = uuid4()
+        service._repo.copy.return_value = {
+            "thread_id": new_id,
+            "metadata": {"foo": "bar"},
+            "status": "idle",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
+        thread = await service.copy(source_id)
+
+        assert thread.thread_id == new_id
+        assert thread.metadata == {"foo": "bar"}
+        assert thread.thread_id != source_id


### PR DESCRIPTION
## Summary
- Thread copy previously only created a new thread record with the same metadata, leaving the new thread empty
- Now copies all LangGraph checkpoint data (checkpoints, checkpoint_blobs, checkpoint_writes) via direct SQL INSERT...SELECT on the checkpointer's psycopg pool
- Gracefully skips checkpoint copy if no checkpointer is configured

## Test plan
- [x] `test_copy_without_checkpointer_returns_new_thread` — empty source thread copies correctly
- [x] `test_copy_without_checkpointer_no_checkpoint_sql` — no error when checkpointer absent
- [x] `test_copy_with_checkpointer_calls_three_inserts` — all three tables are written
- [x] `test_copy_checkpoint_sql_uses_correct_thread_ids` — source/dest IDs are correct in SQL params
- [x] `test_copy_checkpoint_sql_covers_all_tables` — checkpoints, checkpoint_blobs, checkpoint_writes all present
- [x] `test_copy_returns_new_thread_not_source` — returned thread is the new one, not source

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)