### PR TITLE
Fix: load .env at CLI layer so Celery worker sees env vars from langgraph.json

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -19,7 +19,7 @@ globs:
 
 ## App Factory (app.py)
 - `create_app()` with `@asynccontextmanager` for async lifespan
-- **Startup order:** load .env → asyncpg pool → Redis → load graphs → setup checkpointer (psycopg) → setup store (psycopg) → auto-create assistants
+- **Startup order:** (CLI loads .env first) → asyncpg pool → Redis → load graphs → setup checkpointer (psycopg) → setup store (psycopg) → auto-create assistants
 - **Shutdown:** close all pools (checkpointer, store, db, redis)
 - State on `app.state`: `db_pool`, `redis`, `graph_registry`, `checkpointer`, `store`, `settings`, `config`
 
@@ -54,6 +54,9 @@ globs:
 - `langrove serve` — FastAPI via uvicorn (default port 8123)
 - `langrove worker` — Redis Streams consumer + recovery monitor
 - `langrove init` — scaffold langgraph.json + agent.py
+- Both `serve` and `worker` accept `--config` to point at a non-default `langgraph.json`
+- `.env` loading happens in `_load_dotenv_from_config()` at CLI layer, before any langrove module import — this ensures module-level `Settings()` singletons (e.g. Celery app) see the correct env vars
+- 2026-04-09: `.env` must be loaded at CLI level (not app factory) so Celery's module-level Settings() singleton picks it up; loading in app.py is too late
 
 ## Settings (settings.py)
 - Pydantic BaseSettings with `env_prefix="LANGROVE_"` and `.env` file support

--- a/src/langrove/app.py
+++ b/src/langrove/app.py
@@ -29,20 +29,8 @@ from langrove.settings import Settings
 
 def create_app(settings: Settings | None = None, config: GraphConfig | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
-    from dotenv import load_dotenv
-
     settings = settings or Settings()
     config = config or load_config(settings.config_path)
-
-    # Load the .env specified in langgraph.json (defaults to ".env")
-    # Resolved relative to the config file's directory
-    if isinstance(config.env, str):
-        env_path = Path(settings.config_path).parent / config.env
-        load_dotenv(env_path, override=True)
-    elif isinstance(config.env, dict):
-        import os
-
-        os.environ.update(config.env)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/src/langrove/cli.py
+++ b/src/langrove/cli.py
@@ -3,8 +3,47 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import click
+
+# Default config file names searched in order
+_CONFIG_FILENAMES = ("langgraph.json", "aegra.json")
+
+
+def _load_dotenv_from_config(config_path: str) -> None:
+    """Parse langgraph.json and load the .env it specifies.
+
+    Must be called before any langrove module is imported so that
+    module-level Settings() singletons (e.g. in queue/celery_app.py)
+    pick up the correct environment variables.
+
+    Silently skips if the config file is absent or has no ``env`` field.
+    """
+    import json
+
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return  # python-dotenv not installed — nothing to do
+
+    path = Path(config_path)
+    if not path.exists():
+        return
+
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+
+    env_field = data.get("env", ".env")
+    if isinstance(env_field, str):
+        env_path = path.parent / env_field
+        load_dotenv(env_path, override=True)
+    elif isinstance(env_field, dict):
+        import os
+
+        os.environ.update(env_field)
 
 
 def _setup_logging(level: str = "INFO") -> None:
@@ -28,6 +67,13 @@ def main():
 @click.option("--host", default="0.0.0.0", help="Bind host")
 @click.option("--port", default=8123, type=int, help="Bind port")
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development")
+@click.option(
+    "--config",
+    "config_path",
+    default="langgraph.json",
+    show_default=True,
+    help="Path to langgraph.json config file.",
+)
 @click.option("--db-pool-min-size", default=None, type=int, help="Min DB connections (default: 2)")
 @click.option(
     "--db-pool-max-size", default=None, type=int, help="Max DB connections (default: 10)"
@@ -42,6 +88,7 @@ def serve(
     host: str,
     port: int,
     reload: bool,
+    config_path: str,
     db_pool_min_size: int | None,
     db_pool_max_size: int | None,
     log_level: str,
@@ -51,6 +98,7 @@ def serve(
 
     import uvicorn
 
+    _load_dotenv_from_config(config_path)
     _setup_logging(log_level)
 
     if db_pool_min_size is not None:
@@ -102,6 +150,13 @@ def serve(
     type=int,
     help="Graceful shutdown timeout in seconds (default: 30).",
 )
+@click.option(
+    "--config",
+    "config_path",
+    default="langgraph.json",
+    show_default=True,
+    help="Path to langgraph.json config file.",
+)
 @click.option("--db-pool-min-size", default=None, type=int, help="Min DB connections (default: 2)")
 @click.option(
     "--db-pool-max-size", default=None, type=int, help="Max DB connections (default: 10)"
@@ -119,12 +174,15 @@ def worker(
     max_retries: int | None,
     task_timeout: int | None,
     shutdown_timeout: int | None,
+    config_path: str,
     db_pool_min_size: int | None,
     db_pool_max_size: int | None,
     log_level: str,
 ):
     """Start a background run worker (Celery / AsyncIO pool)."""
     import os
+
+    _load_dotenv_from_config(config_path)
 
     from langrove.worker import run_worker
 

--- a/src/langrove/cli.py
+++ b/src/langrove/cli.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 import click
 
-# Default config file names searched in order
-_CONFIG_FILENAMES = ("langgraph.json", "aegra.json")
-
 
 def _load_dotenv_from_config(config_path: str) -> None:
     """Parse langgraph.json and load the .env it specifies.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,80 @@
+"""Tests for CLI .env loading."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+class TestLoadDotenvFromConfig:
+    """Unit tests for _load_dotenv_from_config helper."""
+
+    def test_loads_env_file_from_config_dir(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("TEST_CLI_SENTINEL=hello_from_dotenv\n")
+
+        config_file = tmp_path / "langgraph.json"
+        config_file.write_text(json.dumps({"graphs": {}, "env": ".env"}))
+
+        _load_dotenv_from_config(str(config_file))
+
+        assert os.environ.get("TEST_CLI_SENTINEL") == "hello_from_dotenv"
+        # Cleanup
+        del os.environ["TEST_CLI_SENTINEL"]
+
+    def test_loads_env_dict_from_config(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        config_file = tmp_path / "langgraph.json"
+        config_file.write_text(
+            json.dumps({"graphs": {}, "env": {"TEST_CLI_DICT_KEY": "dict_value"}})
+        )
+
+        _load_dotenv_from_config(str(config_file))
+
+        assert os.environ.get("TEST_CLI_DICT_KEY") == "dict_value"
+        del os.environ["TEST_CLI_DICT_KEY"]
+
+    def test_silently_skips_missing_config(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        # Should not raise
+        _load_dotenv_from_config(str(tmp_path / "nonexistent.json"))
+
+    def test_silently_skips_invalid_json(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        bad_config = tmp_path / "langgraph.json"
+        bad_config.write_text("not valid json")
+
+        # Should not raise
+        _load_dotenv_from_config(str(bad_config))
+
+    def test_env_file_relative_to_config_dir_not_cwd(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        # Place config in a subdirectory, not cwd
+        subdir = tmp_path / "project"
+        subdir.mkdir()
+        env_file = subdir / "custom.env"
+        env_file.write_text("TEST_CLI_SUBDIR=subdir_value\n")
+
+        config_file = subdir / "langgraph.json"
+        config_file.write_text(json.dumps({"graphs": {}, "env": "custom.env"}))
+
+        _load_dotenv_from_config(str(config_file))
+
+        assert os.environ.get("TEST_CLI_SUBDIR") == "subdir_value"
+        del os.environ["TEST_CLI_SUBDIR"]
+
+    def test_missing_env_file_does_not_raise(self, tmp_path: Path):
+        from langrove.cli import _load_dotenv_from_config
+
+        config_file = tmp_path / "langgraph.json"
+        config_file.write_text(json.dumps({"graphs": {}, "env": "missing.env"}))
+
+        # Should not raise even if .env file is absent
+        _load_dotenv_from_config(str(config_file))


### PR DESCRIPTION
## Summary
- Moves `load_dotenv()` from `app.py` into a `_load_dotenv_from_config()` helper in `cli.py`, called before any langrove module import in both `serve` and `worker` commands
- Adds `--config` flag to both commands to support non-default `langgraph.json` paths
- Removes now-redundant dotenv block from `app.py`
- Adds 6 unit tests covering str/dict env fields, missing config, invalid JSON, and relative path resolution

## Test plan
- [ ] `uv run pytest tests/test_cli.py` — all 6 new tests pass
- [ ] `uv run pytest` — full suite (70 tests) passes
- [ ] Manual: start worker from a directory without `.env`; confirm env vars (e.g. `OPENAI_API_KEY`) from config-relative `.env` are present during task execution

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)